### PR TITLE
Java 21 / WildFly 32 / Jakarta EE 10 upgrade — cpp-platform-maven-service-parent-pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ on [Keep a CHANGELOG](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+# [17.104.2] - 2026-03-31
+## Changed
+- Update platform-libraries to 17.104.2 for:
+  - framework-stream-rest-resources dependency is added to expose `/internal` endpoints
+
+### [17.104.1]  - 2026-03-25
+## Added
+- Update platform-libraries to 17.104.1-M2
+- Update event-store to 17.104.1-M2 for:
+  - Notification-based event linking and publishing via CDI events, enabled via JNDI:
+    - event.linking.worker.notified (linking)
+    - event.publishing.worker.notified (publishing)
+  - Bug fixes: dead notifier thread recovery, submit() failure handling
+### Changed
+- Update platform-libraries to 17.104.1-M1
+- Update event-store to 17.104.1-M1 for:
+  - Batch event linking: `EventNumberLinker` now links N events per JTA transaction using JDBC `executeBatch()`,
+    configurable via JNDI `event.linking.worker.batch.size` (default 10)
+
+## [21.0.0-SNAPSHOT] - 2026-04-14
+### Changed
+- Bumped version to `21.0.0-SNAPSHOT` for Java 21 / WildFly 34 migration
+- Updated parent `cpp-platform-libraries-parent-pom` to `21.0.0-SNAPSHOT`
 
 # [17.104.0] - 2025-12-16
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,10 +1,62 @@
-# Readme
-Readme documentation for working within this repository
+# cpp-platform-maven-service-parent-pom
 
-# Release process
+`uk.gov.moj.cpp.common:service-parent-pom`
 
-## Prerequisites
-Prior to performing the release please ensure the following have been performed:
-1. All necessary changes have been merged to master
-2. The CHANGELOG.MD has been updated to document all changes
-3. Ensured all framework, plugin and library versions are current and compatible
+The Maven parent POM for every `cpp-context-*` bounded-context service. It wires together the full dependency stack (framework BOM + platform BOM) and configures all build plugins needed to build a CPP service, including RAML code generation, Liquibase migrations, annotation validation, and WildFly deployment.
+
+## Position in the hierarchy
+
+```
+cpp-platform-maven-parent-pom
+└── cpp-platform-libraries  (platform-libraries-parent-pom)
+    └── cpp-platform-maven-service-parent-pom  ← this project
+        └── [all cpp-context-* bounded-context services]
+```
+
+## Maven coordinates
+
+| Property | Value |
+|---|---|
+| `groupId` | `uk.gov.moj.cpp.common` |
+| `artifactId` | `service-parent-pom` |
+| Parent | `uk.gov.moj.platform.libraries:platform-libraries-parent-pom` (cpp-platform-libraries) |
+
+## What this POM provides
+
+**Dependency imports**
+- `cpp-platform-maven-common-bom` (`uk.gov.moj.cpp.common:common-bom`) — all platform + framework dependency versions
+- `cpp-platform-libraries` BOM (`platform-libraries-bom`) — platform library artifacts at a consistent version
+
+**Code generation plugins** (version-managed; activated per module as needed)
+- `messaging-adapter-generator-plugin` — generates JMS message listener adapters from messaging RAML
+- `messaging-client-generator-plugin` — generates JMS message sender clients
+- `direct-client-generator-plugin` — generates direct (in-process) command clients
+- `rest-client-generator-plugin` — generates REST client stubs from RAML
+- `rest-adapter-generator-plugin` — generates JAX-RS REST resource classes from RAML
+- `unifiedsearch-client-generator-plugin` — generates unified-search query clients
+- `pojo-generation-plugin` — generates Java POJOs from JSON Schema
+- `catalog-generation-plugin` — generates JSON Schema catalog files
+
+**Build conventions for service modules**
+- `cpp.service-component` property — identifies which framework service component type a module provides (`COMMAND_API`, `COMMAND_HANDLER`, `EVENT_LISTENER`, `QUERY_API`, `QUERY_VIEW`, etc.)
+- `cpp.service.name` — service identifier used for JNDI namespace (`java:app/<service.name>/<key>`)
+- Schema generation source directories: `src/raml/json/schema` and `src/main/resources/json/schema`
+- Annotation validation plugin (`annotation-validator-maven-plugin`) — validates `@Handles`, `@ServiceComponent`, and related annotations
+
+**Enforcer rules**
+- Inherits `enforce-moj-latest-interfaces` from `cpp-platform-maven-parent-pom` (cannot be skipped)
+- `enforcer.skipLatestCoreDomainRule` and `enforcer.skipLatestServiceParentPomRule` flags available to temporarily bypass version-freshness checks during development
+
+## Usage
+
+All `cpp-context-*` service modules declare this as their parent:
+
+```xml
+<parent>
+    <groupId>uk.gov.moj.cpp.common</groupId>
+    <artifactId>service-parent-pom</artifactId>
+    <version>${service-parent-pom.version}</version>
+</parent>
+```
+
+The root `pom.xml` of each context project also declares `<cpp.service.name>` to set the JNDI application namespace for that service.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j21
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:service-parent-pom"

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>17.104.0</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>service-parent-pom</artifactId>
-    <version>17.104.1-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Service Parent POM</name>
@@ -32,7 +32,7 @@
 
         <cpp.scm.project>cpp.platform.maven.service-parent-pom</cpp.scm.project>
 
-        <cpp.service-common-resources.version>17.10.1</cpp.service-common-resources.version>
+        <cpp.service-common-resources.version>21.0.0-SNAPSHOT</cpp.service-common-resources.version>
         <activiti.library.version>1.3.1</activiti.library.version>
 
     </properties>
@@ -89,7 +89,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <configuration>
-                        <packagingExcludes>WEB-INF/web.xml</packagingExcludes>
+                        <!-- Exclude web.xml (not required for Jakarta EE) and RESTEasy server JARs
+                             that WildFly provides via its own modules. Bundling RESTEasy in
+                             WEB-INF/lib prevents WildFly's jaxrs subsystem from activating.
+                             Also exclude spring-webmvc which is a transitive dep of activiti-spring
+                             but contains JSP tag classes referencing javax.servlet.jsp which does
+                             not exist in WildFly 32 (Jakarta EE 10). -->
+                        <packagingExcludes>WEB-INF/web.xml,WEB-INF/lib/resteasy-core-*.jar,WEB-INF/lib/resteasy-core-spi-*.jar,WEB-INF/lib/resteasy-jackson-provider-*.jar,WEB-INF/lib/resteasy-multipart-provider-*.jar,WEB-INF/lib/resteasy-servlet-initializer-*.jar,WEB-INF/lib/resteasy-jaxb-provider-*.jar,WEB-INF/lib/jakarta.ws.rs-api-*.jar,WEB-INF/lib/spring-webmvc-*.jar</packagingExcludes>
                         <!-- Java EE 7 doesn't require web.xml, Maven needs to catch up! -->
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                         <webResources>
@@ -284,6 +290,25 @@
 
                 <plugin>
                     <groupId>uk.gov.justice.schema</groupId>
+                    <artifactId>effective-json-schema-maven-plugin</artifactId>
+                    <version>${framework-libraries.version}</version>
+                    <executions>
+                        <execution>
+                            <id>generate-effective-json-schemas</id>
+                            <configuration>
+                                <sourceDirectory>${schema.generation.source.directory}</sourceDirectory>
+                                <outputDirectory>${project.build.directory}/effective-json-schemas</outputDirectory>
+                            </configuration>
+                            <goals>
+                                <goal>generate-effective-json-schemas</goal>
+                            </goals>
+                            <phase>process-sources</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>uk.gov.justice.schema</groupId>
                     <artifactId>catalog-generation-plugin</artifactId>
                     <version>${framework-libraries.version}</version>
 
@@ -416,6 +441,8 @@
                         <exclude>uk/gov/justice/api/resource/*Resource.class</exclude>
                         <exclude>org/drools/compiler/lang/DRL6Lexer*</exclude>
                         <exclude>org/drools/compiler/lang*</exclude>
+                        <exclude>org/drools/drl/parser/lang/DRL6Lexer*</exclude>
+                        <exclude>org/drools/drl/parser/lang*</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -483,6 +510,20 @@
                                     <goal>generate-schema-catalog</goal>
                                 </goals>
                                 <phase>generate-sources</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>uk.gov.justice.schema</groupId>
+                        <artifactId>effective-json-schema-maven-plugin</artifactId>
+                        <version>${framework-libraries.version}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-effective-json-schemas</id>
+                                <goals>
+                                    <goal>generate-effective-json-schemas</goal>
+                                </goals>
+                                <phase>process-sources</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -578,8 +619,7 @@
                             <dependency>
                                 <groupId>javax.xml.bind</groupId>
                                 <artifactId>jaxb-api</artifactId>
-                                <!-- TODO move this version to somewhere sensible -->
-                                <version>2.3.1</version>
+                                <version>${jaxb-api.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -620,8 +660,8 @@
                                 <version>${cpp.framework.version}</version>
                             </dependency>
                             <dependency>
-                                <groupId>javax</groupId>
-                                <artifactId>javaee-api</artifactId>
+                                <groupId>jakarta.platform</groupId>
+                                <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
@@ -670,8 +710,8 @@
                                 <version>${cpp.framework.version}</version>
                             </dependency>
                             <dependency>
-                                <groupId>javax</groupId>
-                                <artifactId>javaee-api</artifactId>
+                                <groupId>jakarta.platform</groupId>
+                                <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
@@ -741,8 +781,8 @@
                                 <version>${cpp.framework.version}</version>
                             </dependency>
                             <dependency>
-                                <groupId>javax</groupId>
-                                <artifactId>javaee-api</artifactId>
+                                <groupId>jakarta.platform</groupId>
+                                <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
@@ -1016,8 +1056,8 @@
                         </executions>
                         <dependencies>
                             <dependency>
-                                <groupId>javax</groupId>
-                                <artifactId>javaee-api</artifactId>
+                                <groupId>jakarta.platform</groupId>
+                                <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>service-parent-pom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Service Parent POM</name>
@@ -32,7 +32,7 @@
 
         <cpp.scm.project>cpp.platform.maven.service-parent-pom</cpp.scm.project>
 
-        <cpp.service-common-resources.version>21.0.0-SNAPSHOT</cpp.service-common-resources.version>
+        <cpp.service-common-resources.version>21.0.0-M1-SNAPSHOT</cpp.service-common-resources.version>
         <activiti.library.version>1.3.1</activiti.library.version>
 
     </properties>


### PR DESCRIPTION
## Summary

- Upgrade to Java 21, WildFly 32, and Jakarta EE 10 (17.104.x backport — Framework E release line)
- Version bumped to `21.0.0-M1-SNAPSHOT`
- `javax.*` → `jakarta.*` namespace migration applied throughout

## Test plan

- [ ] Builds cleanly: `mvn clean install -Denforcer.skip=true`
- [ ] Dependent context services build against this POM

🤖 Generated with [Claude Code](https://claude.ai/claude-code)