### PR TITLE
Java 25 / WildFly 40 spike — service parent POM version bump + jakarta.xml.bind-api fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ on [Keep a CHANGELOG](http://keepachangelog.com/).
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [25.104.0-M1] - 2026-06-10
+### Changed
+- Updated parent `cpp-platform-libraries` to `25.104.0-M1`
+- Updated `cpp.service-common-resources.version` to `25.104.0-M1`
+
 # [17.104.2] - 2026-03-31
 ## Changed
 - Update platform-libraries to 17.104.2 for:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:service-parent-pom"

--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>service-parent-pom</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Service Parent POM</name>
@@ -32,8 +32,10 @@
 
         <cpp.scm.project>cpp.platform.maven.service-parent-pom</cpp.scm.project>
 
-        <cpp.service-common-resources.version>21.0.0-M1-SNAPSHOT</cpp.service-common-resources.version>
+        <cpp.service-common-resources.version>25.104.0-M1</cpp.service-common-resources.version>
         <activiti.library.version>1.3.1</activiti.library.version>
+        <!-- Pinned to pre-EE9 version: generator plugins use javax.xml.bind.* (via raml-parser) which is only present in jakarta.xml.bind-api 2.x. DO NOT upgrade. -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
 
     </properties>
 
@@ -665,6 +667,11 @@
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
                             </dependency>
+                            <dependency>
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <plugin>
@@ -714,6 +721,11 @@
                                 <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -785,6 +797,11 @@
                                 <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
 
                         </dependencies>
@@ -1060,6 +1077,11 @@
                                 <artifactId>jakarta.jakartaee-api</artifactId>
                                 <version>${javaee-api.version}</version>
                                 <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>jakarta.xml.bind</groupId>
+                                <artifactId>jakarta.xml.bind-api</artifactId>
+                                <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
                             <dependency>
                                 <groupId>uk.gov.justice.framework-generators</groupId>


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cpp-platform-maven-service-parent-pom

Spike to prove viability of upgrading the CPP platform directly from Java 17 to **Java 25 / WildFly 40 / Jakarta EE 11** (25.104.0-M1-SNAPSHOT).

**Spike gate: cpp-context-users-groups integration tests — 96/96 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Service parent POM: version bump + jakarta.xml.bind-api:2.3.2 added to all 4 generator plugin dependency blocks (rest-adapter, messaging-adapter, messaging-client, rest-client) to fix javax.xml.bind.SchemaOutputResolver ClassNotFound on Java 25

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
https://github.com/hmcts/cpp-framework-java-upgrade-pilot/blob/main/status/25.104.x-status.md