### PR TITLE
Add parsson to messaging-adapter-generator-plugin classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
         <activiti.library.version>1.3.1</activiti.library.version>
         <!-- Pinned to pre-EE9 version: generator plugins use javax.xml.bind.* (via raml-parser) which is only present in jakarta.xml.bind-api 2.x. DO NOT upgrade. -->
         <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
+        <!-- JSON-P provider for messaging-adapter-generator-plugin; glassfish jakarta.json is an OSGi bundle that suppresses ServiceLoader registration -->
+        <parsson.version>1.1.7</parsson.version>
 
     </properties>
 
@@ -727,6 +729,11 @@
                                 <artifactId>jakarta.xml.bind-api</artifactId>
                                 <version>${jakarta.xml.bind-api.raml.version}</version>
                             </dependency>
+                            <dependency>
+                                <groupId>org.eclipse.parsson</groupId>
+                                <artifactId>parsson</artifactId>
+                                <version>${parsson.version}</version>
+                            </dependency>
                         </dependencies>
                     </plugin>
                     <plugin>
@@ -1092,6 +1099,11 @@
                                 <groupId>uk.gov.justice.services</groupId>
                                 <artifactId>event-subscription</artifactId>
                                 <version>${cpp.framework.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.eclipse.parsson</groupId>
+                                <artifactId>parsson</artifactId>
+                                <version>${parsson.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
## Summary

- Adds `org.eclipse.parsson:parsson:1.1.7` to the `<dependencies>` block of `messaging-adapter-generator-plugin` in both the RAML and YAML generation profiles
- Adds the `parsson.version` property to the service parent POM properties

## Context

`org.glassfish:jakarta.json` is an OSGi bundle that suppresses the `ServiceLoader` registration for `javax.json.spi.JsonProvider`. Without an explicit JSON-P provider on the plugin classpath, the RAML and YAML generators fail to locate the provider at runtime inside the Maven plugin classloader.

Centralising this fix in the service parent POM means every context gets the fix automatically, removing the need for each `cpp-context-*` root pom to redeclare the parsson plugin dependency block.

Part of the 25.104.x Java 25 / WildFly 40 upgrade release chain.

## Test plan

- [ ] `mmse clean install` in `cpp-platform-maven-service-parent-pom` passes locally
- [ ] CI passes
- [ ] After merging as M2, verify `cpp-context-users-groups` and `cpp-context-prosecution-casefile` build without the per-context `messaging-adapter-generator-plugin` parsson block in their root poms

🤖 Generated with [Claude Code](https://claude.com/claude-code)