### PR TITLE
Bump platform-libraries-parent-pom to 25.104.0-M8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>25.104.0-M7</version>
+        <version>25.104.0-M8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## What

Bump the parent `platform-libraries-parent-pom` `25.104.0-M7` → `25.104.0-M8`, which raises `cpp.platform-libraries.version` to `25.104.0-M8` for all context services inheriting this parent.

## Why

M8 contains the fix for the agent prosecutor authority access JSON parsing regression — cpp-platform-libraries **#63**. `ProsecutingAuthorityProvider` was parsing `agentProsecutorAuthorityAccess` (an array of strings) as JsonObjects, throwing at runtime:

```
java.lang.ClassCastException: org.eclipse.parsson.JsonStringImpl cannot be cast to jakarta.json.JsonObject
```

for any user with agent prosecutor access. This surfaced on the Java 25 / WildFly 40 upgrade of `cpp-context-mi-reportdata` (SJP resulted-cases-count and case-export). Releasing this bump lets the affected contexts pick up the fix by moving to the new `service-parent-pom` milestone.

## Verification

Full `mm` build green (enforcer on). M8 parent pom resolves from Artifactory and sets `cpp.platform-libraries.version=25.104.0-M8` (access-control-sjp-providers M8 confirmed to contain the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)