### PR TITLE
Bump parent to platform-libraries M9 and service-common-resources to M2 (M8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [25.104.0-M8] - 2026-07-28
+### Changed
+- Bumped parent `platform-libraries-parent-pom` to `25.104.0-M9` — brings the Elasticsearch **9.2.2** client migration and the full released framework chain (`cpp.platform-libraries.version` M9, `cpp.common-bom.version` M3, `framework.version` M4, `framework-libraries.version` M11, `event-store.version` M5, `file-service.version` M7), including jackson `2.21.5` (**CVE-2026-54515**), the junit-bom import, and the event-store `EntityManagerFlushInterceptor` presence guard, down to consuming context services.
+- Bumped `cpp.service-common-resources.version` to `25.104.0-M2` — picks up platform parent-pom M2 (jacoco 0.8.14 / maven-shade 3.6.0 / buildnumber fix).
+
 ## [25.104.0-M6] - 2026-07-07
 ### Changed
 - Updated parent `platform-libraries-parent-pom` to `25.104.0-M7` — brings `framework.version` `25.104.0-M3`, `event-store.version` `25.104.0-M4`, and `cpp.platform-libraries.version` `25.104.0-M7`, whose event-listener service-component now delivers `persistence-jpa` (the event-stream self-healing `EntityManagerFlushInterceptor` + `EntityManagerProducer`) into consuming context services' event-listener WARs

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.platform.libraries</groupId>
         <artifactId>platform-libraries-parent-pom</artifactId>
-        <version>25.104.0-M8</version>
+        <version>25.104.0-M9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
 
         <cpp.scm.project>cpp.platform.maven.service-parent-pom</cpp.scm.project>
 
-        <cpp.service-common-resources.version>25.104.0-M1</cpp.service-common-resources.version>
+        <cpp.service-common-resources.version>25.104.0-M2</cpp.service-common-resources.version>
         <activiti.library.version>1.3.1</activiti.library.version>
         <!-- Pinned to pre-EE9 version: generator plugins use javax.xml.bind.* (via raml-parser) which is only present in jakarta.xml.bind-api 2.x. DO NOT upgrade. -->
         <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>


### PR DESCRIPTION
Advances **cpp-platform-maven-service-parent-pom** (the parent for all context services) onto the released platform + framework chain.

### Changed
- Parent `platform-libraries-parent-pom` **M8 → M9** — brings the Elasticsearch 9.2.2 client migration and the full released framework chain down to consuming context services: `cpp.platform-libraries.version` M9, `cpp.common-bom.version` M3, `framework.version` M4, `framework-libraries.version` M11, `event-store.version` M5, `file-service.version` M7. Includes jackson 2.21.5 (**CVE-2026-54515**), the junit-bom import, and the event-store `EntityManagerFlushInterceptor` presence guard.
- `cpp.service-common-resources.version` **M1 → M2** (platform parent-pom M2: jacoco 0.8.14 / maven-shade 3.6.0 / buildnumber fix).

Both upstream artifacts verified present in Artifactory (platform-libraries-parent-pom M9, service-common-resources M2). The framework/interface versions themselves are inherited via the parent, not pinned here.

Target: `release/25.104.x` (M7 released, branch on M8-SNAPSHOT → this becomes **M8**).